### PR TITLE
Fix rebalance length mismatch

### DIFF
--- a/already_known.md
+++ b/already_known.md
@@ -1,0 +1,2 @@
+- **Rebalance Length Mismatch**: `_isTargetWeightMet` assumed `basketAssets[i]` and `basketsTargetWeights[i]` had equal lengths. A crafted proposal with extra weight entries triggers an out-of-bounds read during finalisation, reverting and locking the protocol in the `TOKEN_SWAP_PROPOSED` state. Root cause: lack of per-basket length checks on rebalance input arrays.
+

--- a/src/libraries/BasketManagerUtils.sol
+++ b/src/libraries/BasketManagerUtils.sol
@@ -1005,9 +1005,19 @@ library BasketManagerUtils {
         if (self.rebalanceStatus.basketHash != basketHash) {
             revert BasketsMismatch();
         }
-        // Check that the length matches
+        // Check that the outer lengths match
         if (baskets.length != basketsTargetWeights.length || baskets.length != basketAssets.length) {
             revert BasketsMismatch();
+        }
+        // Ensure that each basket asset list matches its target weights length
+        uint256 len = baskets.length;
+        for (uint256 i = 0; i < len;) {
+            if (basketAssets[i].length != basketsTargetWeights[i].length) {
+                revert BasketsMismatch();
+            }
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/test/unit/BasketManager.t.sol
+++ b/test/unit/BasketManager.t.sol
@@ -2322,6 +2322,28 @@ contract BasketManagerTest is BaseTest {
         basketManager.proposeTokenSwap(internalTrades, externalTrades, targetBaskets, targetWeights, basketAssets);
     }
 
+    function test_proposeTokenSwap_revertWhen_AssetWeightLengthMismatch() public {
+        address basket = _setupSingleBasketAndMocks();
+        address[] memory targetBaskets = new address[](1);
+        targetBaskets[0] = basket;
+        vm.prank(rebalanceProposer);
+        basketManager.proposeRebalance(targetBaskets);
+
+        InternalTrade[] memory internalTrades = new InternalTrade[](1);
+        ExternalTrade[] memory externalTrades = new ExternalTrade[](1);
+        uint64[][] memory targetWeights = new uint64[][](1);
+        targetWeights[0] = new uint64[](2);
+        targetWeights[0][0] = 0.5e18;
+        targetWeights[0][1] = 0.5e18;
+        address[][] memory basketAssets = new address[][](1);
+        basketAssets[0] = new address[](1);
+        basketAssets[0][0] = rootAsset;
+
+        vm.expectRevert(BasketManagerUtils.BasketsMismatch.selector);
+        vm.prank(tokenswapProposer);
+        basketManager.proposeTokenSwap(internalTrades, externalTrades, targetBaskets, targetWeights, basketAssets);
+    }
+
     function testFuzz_proposeTokenSwap_revertWhen_internalTradeBasketNotFound(
         uint256 sellWeight,
         uint256 depositAmount,


### PR DESCRIPTION
## Summary
- prevent mismatched asset/weight arrays from locking the rebalance
- add test covering length mismatch
- document the known issue in `already_known.md`

## Testing
- `pnpm test` *(fails: GET https://nodejs.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685cd5718df083288eff3c98b8eedf7c