### PR TITLE
Expand cheat list for auditing guidance

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -4,29 +4,36 @@ This file summarizes recurring patterns and repository-specific details that can
 
 ## Deposit Processing in Cove Contracts
 
-- **_processPendingDeposits** (`src/libraries/BasketManagerUtils.sol` lines 1137‑1169) only calculates how many shares to mint and updates internal balances. It mints shares via `BasketToken.fulfillDeposit` and **does not withdraw liquidity from any external strategy or vault**.
-- When `proposeTokenSwap` handles a rebalance (lines 268‑295 of the same file), it calls `_processPendingDeposits` with the current basket state. The function simply adds the pending deposit amount to the basket’s base asset balance in storage and mints shares.
-- **No code path pulls funds from a strategy to satisfy these deposits.** Tokens used to fulfill deposits are already held in the `BasketToken` contract and are transferred to the BasketManager inside `BasketToken.fulfillDeposit` (`src/BasketToken.sol` lines 460‑494).
-- Therefore, issues claiming that idle balances are ignored when withdrawing to fulfill pending deposits are unfounded unless new code introduces such a withdrawal.
+- **_processPendingDeposits** (`src/libraries/BasketManagerUtils.sol` lines 1137‑1179) computes the shares to mint and updates `basketBalanceOf` without touching external strategies.
+- Deposits are finalized by calling `BasketToken.fulfillDeposit`, which transfers the deposited tokens from the `BasketToken` contract to the BasketManager (`src/BasketToken.sol` lines 460‑494).
+- `proposeTokenSwap` invokes `_processPendingDeposits` at the start of a rebalance (`src/libraries/BasketManagerUtils.sol` lines 268‑295) so the basket balance already includes any pending deposits.
+- **No function withdraws assets from a strategy to fulfill deposits.** Idle balances are handled entirely within the BasketToken and BasketManager contracts.
+- Reports that the protocol ignores idle funds or pulls liquidity from strategies during deposits are false unless these lines change.
 
 ## Redemption Processing
 
-- Pending redemptions are fulfilled by calculating a withdrawal amount (lines 648‑678 of `BasketManagerUtils.sol`) and calling `BasketToken.fulfillRedeem`, which burns shares and transfers assets from the BasketManager back to the token. This withdrawal logic is separate from the deposit flow above.
+- Pending redemptions are processed in `BasketManagerUtils.sol` lines 648‑678. The function calculates a `withdrawAmount` capped by the BasketManager's base-asset balance (lines 664‑665) and then calls `BasketToken.fulfillRedeem` to burn shares and transfer assets.
+- No function pulls funds from external strategies when fulfilling redemptions; the assets are already held by the BasketManager.
 
 Use these references when assessing reports about deposit or redemption logic.
 
 ## Oracle Quote Precision
 
-- All price oracles in the repository operate using **18‑decimal** precision (WAD).
-- `AnchoredOracle` defines `_WAD = 1e18` (`src/oracles/AnchoredOracle.sol` lines 20‑23) and passes values in this format when fetching and validating quotes.
-- The testing `MockPriceOracle` returns quotes scaled by 1e18 (`test/utils/mocks/MockPriceOracle.sol` lines 13‑23), matching the production expectation.
-- `BasketManagerUtils` converts asset balances to USD by calling `EulerRouter.getQuote` and then mixes those results with `_WEIGHT_PRECISION = 1e18` (`src/libraries/BasketManagerUtils.sol` lines 60‑64 and 1188‑1207).
-- Therefore, any report claiming that oracle quotes use a 6‑decimal format or that a 6/18 decimal mismatch exists is incorrect unless new code explicitly changes the quote precision.
+- All price oracles operate using **18‑decimal WAD precision**.
+- `AnchoredOracle` sets `_WAD = 1e18` (`src/oracles/AnchoredOracle.sol` lines 20‑23) and validates quotes using this scale.
+- `MockPriceOracle` in the test suite multiplies prices by `1e18` before returning a value (`test/utils/mocks/MockPriceOracle.sol` lines 13‑23).
+- `BasketManagerUtils` relies on `_WEIGHT_PRECISION = 1e18` (`src/libraries/BasketManagerUtils.sol` lines 60‑64) and converts balances to USD via `EulerRouter.getQuote` in `_calculateBasketValue` (lines 1188‑1207), which expects 18‑decimal inputs.
+- Thus, claims of a 6‑decimal oracle format or mismatched precision are false unless the code around these lines is modified.
 
 ## External Trade Weight Enforcement
 
-- `completeRebalance` (`src/libraries/BasketManagerUtils.sol` line 395) finalizes a rebalance after the delay period.
-- When external trades are executed, `_processExternalTrades` is called at line 420 to update `basketBalanceOf` with the actual amounts returned from `_completeTokenSwap`.
-- Immediately after processing swaps, the function re-runs `_initializeBasketData` and `_isTargetWeightMet` (lines 428‑444) to recompute basket values using real balances.
-- If any basket's weights exceed `weightDeviationLimit`, the rebalance status is reset to `REBALANCE_PROPOSED` and the transaction reverts, preventing proposals from understating `minAmount` to bypass weight checks.
-- `_validateExternalTrades` (lines 908‑991) only simulates trades using each trade's `minAmount`, so weight deviations must still pass the post-swap check in `completeRebalance`.
+- `completeRebalance` (`src/libraries/BasketManagerUtils.sol` line 395) ends the rebalance after the mandatory delay.
+- `_processExternalTrades` (line 420) applies the amounts returned from `_completeTokenSwap` to `basketBalanceOf`.
+- The balances are then re-evaluated via `_initializeBasketData` and `_isTargetWeightMet` (lines 428‑444). If any basket weight deviates beyond `weightDeviationLimit`, the function reverts and sets the status back to `REBALANCE_PROPOSED`.
+- `_validateExternalTrades` (lines 908‑991) merely simulates trades using their `minAmount`; the final weight check in `completeRebalance` must still pass with real claimed amounts.
+
+## Token Swap Execution Authorization
+
+- `BasketManager.executeTokenSwap` (`src/BasketManager.sol` lines 412‑447) is protected by `onlyRole(_TOKENSWAP_EXECUTOR_ROLE)`. Unauthorized callers will revert via AccessControl.
+- The function validates the current status is `TOKEN_SWAP_PROPOSED` and ensures the passed `externalTrades` hash matches the stored proposal before setting the status to `TOKEN_SWAP_EXECUTED` and delegate-calling the adapter.
+- Any report suggesting this function is publicly callable or lacks authorization checks is incorrect unless these lines change.


### PR DESCRIPTION
## Summary
- update cheat_list with detailed explanations
- add section about access control on `executeTokenSwap`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cd5aa23dc83289dde8cffca5084b4