### PR TITLE
Improve cheat list coverage for redemption logic

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -18,9 +18,11 @@ automated reviews.
 
 ## Redemption Processing
 
-- Pending redemptions are processed in `BasketManagerUtils.sol` lines 648‑678. The function calculates a
-  `withdrawAmount` capped by the BasketManager's base-asset balance (lines 664‑665) and then calls
-  `BasketToken.fulfillRedeem` to burn shares and transfer assets.
+- Pending redemptions are processed in `BasketManagerUtils.sol` lines 648‑678. The function converts the
+  USD value owed to redeemers back into the basket's base asset using
+  `eulerRouter.getQuote` (lines 659‑663) and stores the result in `withdrawAmount`.
+- `withdrawAmount` is capped by the BasketManager's base‑asset balance (lines 664‑665) before
+  calling `BasketToken.fulfillRedeem` to burn shares and transfer assets.
 - No function pulls funds from external strategies when fulfilling redemptions; the assets are already held by the
   BasketManager.
 


### PR DESCRIPTION
## Summary
- expand the notes in `cheat_list.md` about how pending redemptions are handled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ce7568a588328a4dbf62e7a75f4a5