### PR TITLE
Update cheat_list with deposit precision note

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -7,6 +7,11 @@ automated reviews.
 
 - **\_processPendingDeposits** (`src/libraries/BasketManagerUtils.sol` lines 1137‑1179) computes the shares to mint and
   updates `basketBalanceOf` without touching external strategies.
+- When `basketValue` and `totalSupply` are zero, the minted shares equal
+  `pendingDepositValue` returned by `eulerRouter.getQuote` (`src/libraries/BasketManagerUtils.sol`
+  lines 1163‑1168). `pendingDepositValue` uses 18‑decimal USD precision so the
+  share supply aligns with the 18‑decimal `decimals()` in `BasketToken.sol`
+  (lines 1125‑1130).
 - Deposits are finalized by calling `BasketToken.fulfillDeposit`, which transfers the deposited tokens from the
   `BasketToken` contract to the BasketManager (`src/BasketToken.sol` lines 460‑494).
 - `proposeTokenSwap` invokes `_processPendingDeposits` at the start of a rebalance


### PR DESCRIPTION
## Summary
- document that `_processPendingDeposits` mints shares using the USD value returned by `eulerRouter.getQuote` when the basket is empty
- reference relevant source lines to show the 18‑decimal scaling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ce70141f4832894c988970bf14e2b