### PR TITLE
Document loops in _processExternalTrades

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -53,6 +53,7 @@ Use these references when assessing reports about deposit or redemption logic.
 
 - `completeRebalance` (`src/libraries/BasketManagerUtils.sol` line 395) ends the rebalance after the mandatory delay.
 - `_processExternalTrades` (line 420) applies the amounts returned from `_completeTokenSwap` to `basketBalanceOf`.
+- The nested loops inside this function increment their counters (`++j` at line 761 and `++i` at line 766) so execution always progresses; reports of missing increments causing an infinite loop are false unless these lines change.
 - The balances are then re-evaluated via `_initializeBasketData` and `_isTargetWeightMet` (lines 428‑444). If any basket weight deviates beyond `weightDeviationLimit`, the function reverts and sets the status back to `REBALANCE_PROPOSED`.
 - `_validateExternalTrades` (lines 908‑991) merely simulates trades using their `minAmount`; the final weight check in `completeRebalance` must still pass with real claimed amounts.
 - As a result, finalization without calling `executeTokenSwap` is only possible when the baskets already meet their target weights or when the retry limit (`self.retryLimit`) has been reached.  Otherwise `_isTargetWeightMet` fails and the rebalance restarts.


### PR DESCRIPTION
## Summary
- add cheat list bullet clarifying that `_processExternalTrades` increments loop counters, preventing infinite loops

## Testing
- `pnpm test` *(fails: Forbidden 403 fetching Node.js)*

------
https://chatgpt.com/codex/tasks/task_e_685cecf943cc83289388f55b46d98084